### PR TITLE
[ota] feat: 画像プリフェッチ機能を追加してスクロール時の表示をスムーズに改善

### DIFF
--- a/tiktok-ui/App.tsx
+++ b/tiktok-ui/App.tsx
@@ -26,6 +26,28 @@ const generateImages = (count: number): ImageItem[] => {
   }));
 };
 
+// Separate component for image item to properly use hooks
+function ImageItemComponent({ item }: { item: ImageItem }) {
+  const [imageLoading, setImageLoading] = useState(true);
+
+  return (
+    <View style={styles.imageContainer}>
+      {imageLoading && (
+        <View style={styles.imageLoadingContainer}>
+          <ActivityIndicator size="large" color="#ffffff" />
+        </View>
+      )}
+      <Image
+        source={{ uri: item.uri }}
+        style={styles.image}
+        resizeMode="cover"
+        onLoadStart={() => setImageLoading(true)}
+        onLoadEnd={() => setImageLoading(false)}
+      />
+    </View>
+  );
+}
+
 export default function App() {
   const [images, setImages] = useState<ImageItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -80,24 +102,7 @@ export default function App() {
   }).current;
 
   const renderItem = ({ item, index }: { item: ImageItem; index: number }) => {
-    const [imageLoading, setImageLoading] = useState(true);
-
-    return (
-      <View style={styles.imageContainer}>
-        {imageLoading && (
-          <View style={styles.imageLoadingContainer}>
-            <ActivityIndicator size="large" color="#ffffff" />
-          </View>
-        )}
-        <Image
-          source={{ uri: item.uri }}
-          style={styles.image}
-          resizeMode="cover"
-          onLoadStart={() => setImageLoading(true)}
-          onLoadEnd={() => setImageLoading(false)}
-        />
-      </View>
-    );
+    return <ImageItemComponent item={item} />;
   };
 
   if (loading) {

--- a/tiktok-ui/App.tsx
+++ b/tiktok-ui/App.tsx
@@ -127,7 +127,6 @@ export default function App() {
         snapToInterval={SCREEN_HEIGHT}
         snapToAlignment="start"
         decelerationRate="fast"
-        vertical
         bounces={false}
         onViewableItemsChanged={onViewableItemsChanged}
         viewabilityConfig={viewabilityConfig}


### PR DESCRIPTION
## Summary

スクロール直後に画像が表示されない問題を解決するため、画像の複数先読み機能を実装しました。

## Changes

- `Image.prefetch()`を使用して現在位置の前後3枚ずつの画像を先読み
- `onViewableItemsChanged`で現在表示中の画像を追跡
- 各画像にローディングインジケーターを追加
- プリフェッチ済み画像の管理で効率化

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)